### PR TITLE
Using continue like this generates an error in  php 7.3

### DIFF
--- a/CRM/Rpow/Classifier.php
+++ b/CRM/Rpow/Classifier.php
@@ -146,7 +146,7 @@ class CRM_Rpow_Classifier {
         case $BACK:
           if ($char === $ESCAPE) {
             $esc = TRUE;
-            continue;
+            break;
           }
           elseif ($char === $mode && !$esc) {
             $mode = $PLAIN;


### PR DESCRIPTION
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?

If we change to break there is no change in functionality - the point of the mention of continue 2 in the message is there is a chance the wrong term was used but I don't think that is the case & fixing to 'break' is the same but less noisy