### PR TITLE
Add constant CIVICRM_DRUSH_DSN …

### DIFF
--- a/rpow.php
+++ b/rpow.php
@@ -40,6 +40,7 @@ function rpow_init($config = []) {
   }
 
   define('CIVICRM_DSN', 'civirpow://');
+  define('CIVICRM_DRUSH_DSN', $config['masters'][0]);
   // define('CIVICRM_DSN', $config['masters'][0]);
   // define('CIVICRM_DSN', $config['slaves'][0]);
 }

--- a/rpow.php
+++ b/rpow.php
@@ -40,7 +40,21 @@ function rpow_init($config = []) {
   }
 
   define('CIVICRM_DSN', 'civirpow://');
-  define('CIVICRM_DRUSH_DSN', $config['masters'][0]);
+  switch (getenv('RPOW') ?: '') {
+    case 'ro':
+    case 'slave':
+      define('CIVICRM_CLI_DSN', $config['slaves'][0] ?? $config['masters'][0]);
+      break;
+    case 'rw':
+    case 'master':
+    case '':
+      define('CIVICRM_CLI_DSN', $config['masters'][0]);
+      break;
+
+    default:
+      throw new \Exception("Unrecognized RPOW");
+  }
+
   // define('CIVICRM_DSN', $config['masters'][0]);
   // define('CIVICRM_DSN', $config['slaves'][0]);
 }


### PR DESCRIPTION
This creates CIVICRM_DRUSH_DSN to use the "master" db for drush commands.  Drupal's drush_convert_db_from_db_url function assumes a more basic mysql connection string and I assumed we'd want a db with write permissions for drush operations. I've also created https://github.com/civicrm/civicrm-drupal/pull/613 to go along with this change.