### PR TITLE
Add work around for cookies in tests. Fixes #8

### DIFF
--- a/rpow.php
+++ b/rpow.php
@@ -78,6 +78,11 @@ function _rpow_update_cookie($config, $db) {
     'sig' => $signer->sign(['exp' => $expires]),
     'cause' => $buffer,
   ]);
+  if (defined('CIVICRM_TEST') && CIVICRM_TEST) {
+    // Return before setting a cookie in the test context as it can
+    // cause test mischief - ie. https://github.com/totten/rpow/issues/8
+    return;
+  }
   setcookie($config['cookieName'], $value, $expires, '/');
 }
 


### PR DESCRIPTION
Rudimentary fix for https://github.com/totten/rpow/issues/8

Requires test bootstrap to define CIVICRM_TEST & if so set_cookies is suppressed