### PR TITLE
Support ssl in rpow connections

### DIFF
--- a/DB/civirpow.php
+++ b/DB/civirpow.php
@@ -53,7 +53,9 @@ class DB_civirpow extends DB_mysqli {
 
     $chosenDsn = $dsns[0];
     // If you want to inspect the connection+reconnection process, this is a handy place for a breakpoint. Note $state and $chosenDsn.
-    return parent::connect(DB::parseDSN($chosenDsn), $persistent);
+    $parsedDSN = DB::parseDSN($chosenDsn);
+    $this->setOption('ssl', $parsedDSN['ssl'] ?? 0);
+    return parent::connect($parsedDSN, $persistent);
   }
 
   public function simpleQuery($query) {


### PR DESCRIPTION
It seems we just need to teach rpow to parse our civi-specific url param

See https://docs.civicrm.org/installation/en/latest/general/mysql_tls/#dsn-settings