### PR TITLE
Switch to read-write when information_schema is queried

### DIFF
--- a/CRM/Rpow/Classifier.php
+++ b/CRM/Rpow/Classifier.php
@@ -67,6 +67,12 @@ class CRM_Rpow_Classifier {
         preg_match('; (for update|for share|into outfile|into dumpfile);', $sql)
         // ^^keywords
 
+        // Checks on the information_schema might be used to determine which indexes to add etc.
+        // A read only user is likely to be lacking permission on the information_schema - meaning
+        // it would be silently misinformed about existing indexes etc which could lead to the
+        // check to ensure they are only added if they do not already exist failing.
+        || preg_match('; information_schema\.;', $sql)
+
         // FIXME: This is more correct, but civicrm-core may be a bit too eager with using them?
         || preg_match(';[ ,\(](get_lock|is_free_lock|is_used_lock) *\(;S', $sql)
         // ^^functions

--- a/info.xml
+++ b/info.xml
@@ -23,7 +23,7 @@
   <comments>This extension allows you to define a second read only database connection for load balancing. Operations that do not need to write to the database will use it</comments>
   <civix>
     <namespace>CRM/Rpow</namespace>
-    <format>23.02.1</format>
+    <format>25.01.1</format>
   </civix>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/rpowdbg/rpowdbg.civix.php
+++ b/rpowdbg/rpowdbg.civix.php
@@ -243,7 +243,7 @@ function _rpowdbg_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;


### PR DESCRIPTION
Per code comments - this addresses a situation where the read only user cannot query the information_schema and the non-results might lead to incorrect alter statements (trying to add indices that already exist but can't be seen by that user