### PR TITLE
Update paths to reflect standalone

### DIFF
--- a/bin/harvey-dent
+++ b/bin/harvey-dent
@@ -2,7 +2,7 @@
 
 CIVIRPOWBIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CIVIRPOWDIR="$(dirname $CIVIRPOWBIN)"
-DEV_SETTINGS_PHP=sites/default/civicrm.settings.d/pre.d/100-civirpow.php
+DEV_SETTINGS_PHP=private/civicrm.settings.d/pre.d/100-civirpow.php
 SITE_ROOT=
 CIVIRO_USER=civiro
 CIVIRO_PASS=r3ad0n1yt0ps3cr3t

--- a/bin/rebuild-ro
+++ b/bin/rebuild-ro
@@ -4,7 +4,7 @@ CIVIRPOWBIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CIVIRPOWDIR="$(dirname $CIVIRPOWBIN)"
 
 TMP_SQL_FILE=$(php -r 'echo sys_get_temp_dir() . DIRECTORY_SEPARATOR . "civiro.sql";')
-DEV_SETTINGS_PHP=sites/default/civicrm.settings.d/pre.d/100-civirpow.php
+DEV_SETTINGS_PHP=private/civicrm.settings.d/pre.d/100-civirpow.php
 SITE_ROOT=
 CIVIRO_USER=civiro
 CIVIRO_PASS=r3ad0n1yt0ps3cr3t


### PR DESCRIPTION
Updates the path in the 2 scripts that WMF seems to use to the standalone paths. I guess the install.md is fine & the last one does CMS stuff too.

Obviously hard-coding is ... hard-coding. But if it's gonna be hard-coded then reflecting the primary user of the extension (only known user) makes sense